### PR TITLE
Add OSCA KANO

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A list of Open Source communities in Africa
 
 ## Western Africa
 
-- [Opensorce Community Afrcia - Kano chapter (OSCA Kano)](https://twitter.com/osca_kano)
+- [Opensorce Community Afrcia - Kano Chapter (OSCA Kano)](https://twitter.com/osca_kano)
 - [Open Source Community Africa - Lomé chapter (OSCA Lomé)](https://twitter.com/osca_lome)
 - [OSS Cameroom](https://osscameroon.com/)
 - [Python Benin](https://twitter.com/PythonBenin)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 A list of Open Source communities in Africa
 
-
 ## Central Africa || Middle Africa
+
 - [Angola Open Source Community](https://github.com/angolaosc)
 
-
 ## Eastern Africa
+
 - [CyberStorm](https://cyberstorm.mu/)
 - [Linux User Group of Mauritius](https://lugm.org/)
 - [Python Kampala](https://www.meetup.com/pykampala/)
@@ -16,26 +16,28 @@ A list of Open Source communities in Africa
 - [SpaceYaTech](https://linktr.ee/spaceyatech)
 
 ## Northern Africa
+
 - [Ubuntu Egypt](https://www.facebook.com/groups/ubuntueg/)
 
-
 ## Southern Africa
+
 - [Gauteng Python User Group](https://www.meetup.com/gauteng-python-users-group/)
 - [PyData Johannesburg](https://www.meetup.com/pydata-johannesburg/)
 - [Python Namibia](https://twitter.com/PythonNamibia)
 - [ZimboPy](https://twitter.com/zimbopy?lang=en)
 
-
 ## Western Africa
+
 - [Open Source Community Africa - Lomé chapter (OSCA Lomé)](https://twitter.com/osca_lome)
+- [Opensorce Community Afrcia - Kano chapter (OSCA Kano)](https://twitter.com/osca_kano)
 - [OSS Cameroom](https://osscameroon.com/)
 - [Python Benin](https://twitter.com/PythonBenin)
 - [Python Cote d'ivoire](https://www.facebook.com/PythonCI/)
 - [Python Ghana](https://www.pythonghana.org/)
 - [Python Nigeria](https://twitter.com/PythonNigeria)
 
-
 ## Pan-African Communities
+
 - [Afrodjango Initiatives](http://www.afrodjangoinitiatives.org/)
 - [CHAOSS Africa](https://chaoss.community/kb/chaoss-africa/)
 - [Masakhane](https://www.masakhane.io/)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ A list of Open Source communities in Africa
 
 ## Western Africa
 
-- [Open Source Community Africa - Lomé chapter (OSCA Lomé)](https://twitter.com/osca_lome)
 - [Opensorce Community Afrcia - Kano chapter (OSCA Kano)](https://twitter.com/osca_kano)
+- [Open Source Community Africa - Lomé chapter (OSCA Lomé)](https://twitter.com/osca_lome)
 - [OSS Cameroom](https://osscameroon.com/)
 - [Python Benin](https://twitter.com/PythonBenin)
 - [Python Cote d'ivoire](https://www.facebook.com/PythonCI/)


### PR DESCRIPTION
OSCA KANO is a local chapter of Opensource Community Africa, base in Kano Nigeria